### PR TITLE
allow uploading multiple and visualization

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,47 +10,49 @@
     <script src="upload.js" defer></script>
   </head>
   <body class="state-authentication-error">
-    <img id="selected" />
-    <h1>moments</h1>
-    <div id="authentication-error">
-      <div class="inner">Reload to reauthenticate</div>
-    </div>
-    <div id="select-first">
-      <button id="button-select-first" class="inner">Select</button>
-    </div>
-    <div id="ready-to-upload">
-      <button id="select-button-ready-to-upload" class="inner">Reselect</button>
-      <button id="upload-button-ready-to-upload" class="inner">Upload</button>
-    </div>
-    <div id="progress">
-      <img class="inner monkey" src="emojis/monkey.gif" />
-    </div>
-    <div id="select-another">
-      <div class="inner">
-        <img
-          src="emojis/white-heavy-check-mark_2705.png"
-          class="emoji"
-          alt="✅"
-        />
-        <img src="emojis/bottle-with-popping-cork_1f37e.png" class="emoji" alt="🍾" />
-        <img src="emojis/party-popper_1f389.png" class="emoji" alt="🎉" />
+    <div id="image-staging">
+      <div id="selected-images"></div>
+      <h1>moments</h1>
+      <div id="authentication-error">
+        <div class="inner">Reload to reauthenticate</div>
       </div>
-      <div class="inner">
-        <button id="button-select-another">Select</button>
+      <div id="select-first">
+        <button id="button-select-first" class="inner">Select</button>
       </div>
-    </div>
-    <div id="select-another-after-error">
-      <div class="inner">
-        <img src="emojis/cross-mark_274c.png" class="emoji" alt="❌" />
-        <img
-          src="emojis/shocked-face-with-exploding-head_1f92f.png"
-          class="emoji"
-          alt="🤯"
-        />
+      <div id="ready-to-upload">
+        <button id="select-button-ready-to-upload" class="inner">Reselect</button>
+        <button id="upload-button-ready-to-upload" class="inner">Upload</button>
       </div>
-      <div id="error-reason" class="inner"></div>
-      <div class="inner">
-        <button id="button-select-another-after-error">Select</button>
+      <div id="progress">
+        <img class="inner monkey" src="emojis/monkey.gif" />
+      </div>
+      <div id="select-another">
+        <div class="inner">
+          <img
+            src="emojis/white-heavy-check-mark_2705.png"
+            class="emoji"
+            alt="✅"
+          />
+          <img src="emojis/bottle-with-popping-cork_1f37e.png" class="emoji" alt="🍾" />
+          <img src="emojis/party-popper_1f389.png" class="emoji" alt="🎉" />
+        </div>
+        <div class="inner">
+          <button id="button-select-another">Select</button>
+        </div>
+      </div>
+      <div id="select-another-after-error">
+        <div class="inner">
+          <img src="emojis/cross-mark_274c.png" class="emoji" alt="❌" />
+          <img
+            src="emojis/shocked-face-with-exploding-head_1f92f.png"
+            class="emoji"
+            alt="🤯"
+          />
+        </div>
+        <div id="error-reason" class="inner"></div>
+        <div class="inner">
+          <button id="button-select-another-after-error">Select</button>
+        </div>
       </div>
     </div>
   </body>

--- a/frontend/upload.css
+++ b/frontend/upload.css
@@ -14,15 +14,30 @@ body {
   overflow: hidden;
 }
 
-img#selected {
+#selected-images {
   position: absolute;
-  display: none;
-  width: 100vw;
-  height: 100vh;
+  inset: 0;
+  display: flex;
+  max-width: 100vw;
+  max-height: 100vh;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+  padding: 10px;
+  overflow: hidden;
+  z-index: 0;
+}
+
+#selected-images img {
+  flex: 0 1 auto;
+  max-height: 100%;
+  height: auto;
+  width: auto;
   object-fit: contain;
   border: none;
   outline: none;
-  z-index: 0;
+  z-index: inherit;
 }
 
 h1 {
@@ -40,6 +55,12 @@ h1 {
 }
 
 /* styles */
+#image-staging {
+  position: relative;
+  width: 100vw;
+  height: 100vh;
+  overflow: hidden;
+}
 
 #authentication-error,
 #select-first,

--- a/frontend/upload.js
+++ b/frontend/upload.js
@@ -37,27 +37,79 @@ if (window.location.hash) {
   })();
 }
 
-let objectUrl = null;
-const selectedImage = document.getElementById("selected");
-selectedImage.onload = () => {
-  URL.revokeObjectURL(objectUrl);
-  selectedImage.style.setProperty("display", "block");
-  document.body.className = "state-ready-to-upload";
-};
-selectedImage.onerror = (error) => {
-  selectedImage.style.setProperty("display", "none");
-  selectedImage.removeAttribute("src");
-  console.error(error);
-  alert(`Failed to display image: ${error}`);
-  document.body.className = "state-select-first";
-};
+const selectedImagesContainer = document.getElementById("selected-images");
+let selectedFiles = [];
 
 const filePicker = document.createElement("input");
+filePicker.multiple = true;
 filePicker.type = "file";
 filePicker.accept = "image/bmp,image/jpeg,image/png,image/tiff,image/webp";
+let previewedFiles = [];
+
 filePicker.addEventListener("change", () => {
-  selectedImage.src = URL.createObjectURL(filePicker.files[0]);
+  selectedFiles = Array.from(filePicker.files);
+  selectedImagesContainer.innerHTML = "";
+
+  if (selectedFiles.length === 0) {
+    document.body.className = "state-select-first";
+    return;
+  }
+
+  loadImages(selectedFiles);
 });
+
+async function loadImages(files) {
+  previewedFiles = [];
+
+  const loadImage = (file) => {
+    return new Promise((resolve, reject) => {
+      const img = document.createElement("img");
+      const objectUrl = URL.createObjectURL(file);
+      img.src = objectUrl;
+
+      img.onload = () => {
+        URL.revokeObjectURL(objectUrl);
+        resolve({ img, file });
+      };
+
+      img.onerror = (error) => {
+        URL.revokeObjectURL(objectUrl);
+        reject({ error, file });
+      };
+    });
+  };
+
+  const loadPromises = files.map((file) => loadImage(file).catch((e) => e));
+
+  const results = await Promise.all(loadPromises);
+
+  const successfulResults = results.filter((r) => !r.error);
+  const failedResults = results.filter((r) => r.error);
+
+  const count = successfulResults.length;
+  let maxWidth = "100%";
+  if (count > 0) {
+    maxWidth = `${Math.floor(100 / Math.min(count, 5))}%`;
+  }
+
+  selectedImagesContainer.innerHTML = "";
+
+  successfulResults.forEach(({ img, file }) => {
+    img.style.setProperty("max-width", maxWidth);
+    selectedImagesContainer.appendChild(img);
+    previewedFiles.push(file);
+  });
+
+  if (failedResults.length > 0) {
+    failedResults.forEach(({ file }) => {
+      console.warn(`Failed to load image preview for: ${file.name}`);
+    });
+    alert(`${failedResults.length} image(s) failed to load and won't be uploaded.`);
+  }
+
+  document.body.className = successfulResults.length > 0 ? "state-ready-to-upload" : "state-select-first";
+}
+
 
 selectButtons.forEach((selectButton) =>
   selectButton.addEventListener("click", () => {
@@ -66,28 +118,62 @@ selectButtons.forEach((selectButton) =>
 );
 
 uploadButton.addEventListener("click", async () => {
-  const form = new FormData();
-  form.append("image", filePicker.files[0]);
-  try {
-    document.body.className = "state-progress";
-    const response = await fetch(
-      new URL(
-        `./${window.location.hash.substring(1).toLowerCase()}/upload`,
-        window.location
-      ),
-      {
+  if (previewedFiles.length === 0) {
+    alert("No valid images to upload.");
+    return;
+  }
+
+  document.body.className = "state-progress";
+  const secret = window.location.hash.substring(1).toLowerCase();
+  const uploadUrl = new URL(`./${secret}/upload`, window.location);
+
+  const uploadPromises = previewedFiles.map(async (file) => {
+    const form = new FormData();
+    form.append("image", file);
+    try {
+      const response = await fetch(uploadUrl, {
         method: "POST",
         body: form,
+      });
+      if (!response.ok) {
+        throw await response.text();
       }
-    );
-    if (!response.ok) {
-      throw await response.text();
+      return { file, success: true };
+    } catch (error) {
+      return { file, success: false, error };
     }
-    document.body.className = "state-select-another";
-  } catch (error) {
-    document.body.className = "state-select-another-after-error";
-    document.getElementById("error-reason").innerText = error;
-  }
-  selectedImage.style.setProperty("display", "none");
-  selectedImage.removeAttribute("src");
+  });
+
+  const results = await Promise.allSettled(uploadPromises);
+
+  selectedImagesContainer.innerHTML = "";
+
+  const ul = document.createElement("ul");
+
+  results.forEach((result) => {
+    const li = document.createElement("li");
+    if (result.status === "fulfilled") {
+      const { file, success, error } = result.value;
+      li.textContent = success
+        ? `✅ Uploaded: ${file.name}`
+        : `❌ Failed: ${file.name} - ${error}`;
+    } else {
+      li.textContent = `❌ Unexpected error during upload.`;
+    }
+    ul.appendChild(li);
+  });
+
+  selectedImagesContainer.appendChild(ul);
+
+  const hasErrors = results.some(
+    (result) => result.status !== "fulfilled" || !result.value.success
+  );
+
+  document.body.className = hasErrors
+    ? "state-select-another-after-error"
+    : "state-select-another";
+
+  previewedFiles = [];
+  selectedFiles = [];
+  filePicker.value = "";
 });


### PR DESCRIPTION
## Why? What?

Support uploading of multiple images including handling errors thrown for selecting and uploading each image individually.

Fixes #16 

## ToDo / Known Issues

- [ ] Dynamically choose number of images to display per row
- [ ] Limit number of images that can be uploaded at a time?
- [ ] Server side rate limiting (queue of images?) in order to prevent one person from filling up the entire kiosk with one set of images. These images should maybe appear one after another over some period of time.

## Ideas for Next Iterations (Not This PR)

- [ ] Rate limiting of uploads on an IP basis or similar in order to prevent spamming?

## How to Test

- Set secret in yaml
- `Docker compose up`
- Go to `0:0:0:0:3000`
- Press select button and select multiple images, try around with upload/select buttons and see resulting error messages when unsupported images/duplicate images are uploaded.
- Successful uploads should be reflected in the kiosk

