### PR TITLE
create multiple parallel but offset runners for kiosk highlighting

### DIFF
--- a/frontend/kiosk.js
+++ b/frontend/kiosk.js
@@ -13,7 +13,7 @@ const options = {
   popDownDuration: baseDuration * 0.75,
   allowedRelativeWidthFromCenterForAdditions: 0.4, // from center in one direction, so actually twice
   easing: "cubic-bezier(0.65, 0.05, 0.36, 1)",
-  amountOfRows: 8,
+  amountOfRows: 4,
   stopIteration: false,
   secret: window.location.hash.substring(1),
 };
@@ -202,7 +202,7 @@ async function addImagesUntilScreenIsFull(options, rows, recommender) {
 
 const activeRegions = [];
 
-function rectsOverlap(a, b, buffer = 20) {
+function rectsOverlap(a, b, buffer = 100) {
   return !(
     a.right + buffer < b.left - buffer ||
     a.left - buffer > b.right + buffer ||
@@ -246,25 +246,27 @@ async function addImage(options, rows, recommender) {
     recommender,
   );
   const width = ((100 / options.amountOfRows) / image.naturalHeight) * image.naturalWidth;
+  const height = (100 / options.amountOfRows);
 
-  const region = image.getBoundingClientRect();
+  const finalHeight = (height / 100) * window.innerHeight;
+  const finalWidth = (width / 100) * window.innerHeight;
+  
+  const scaledWidth = finalWidth * options.highlightScale;
+  const scaledHeight = finalHeight * options.highlightScale;
+
+  const imageRegion = image.getBoundingClientRect();
+  
+  const region = {
+    left: imageRegion.x - scaledWidth / 2,
+    right: imageRegion.x + scaledWidth / 2,
+    top: imageRegion.y - scaledHeight / 2,
+    bottom: imageRegion.y + scaledHeight / 2,
+  };
+  
   console.log(region)
-  console.log(width)
-
-  const scaledWidth = region.width * options.highlightScale;
-  const scaledHeight = region.height * options.highlightScale;
-
-  region.x -= (scaledWidth - region.width);
-  region.y -= (scaledHeight - region.height);
-  region.width = scaledWidth;
-  region.height = scaledHeight;
-  region.right = region.x + region.width;
-  region.bottom = region.y + region.height;
-  region.left = region.x;
-  region.top = region.y;
-
+  
   while (!isRegionFree(region)) {
-    await sleep(50); // wait & retry
+    await sleep(50);
   }
 
   addActiveRegion(region);

--- a/frontend/kiosk.js
+++ b/frontend/kiosk.js
@@ -13,7 +13,7 @@ const options = {
   popDownDuration: baseDuration * 0.75,
   allowedRelativeWidthFromCenterForAdditions: 0.4, // from center in one direction, so actually twice
   easing: "cubic-bezier(0.65, 0.05, 0.36, 1)",
-  amountOfRows: 5,
+  amountOfRows: 8,
   stopIteration: false,
   secret: window.location.hash.substring(1),
 };
@@ -245,9 +245,11 @@ async function addImage(options, rows, recommender) {
     imagesInRow,
     recommender,
   );
-  const width = (20 / image.naturalHeight) * image.naturalWidth;
+  const width = ((100 / options.amountOfRows) / image.naturalHeight) * image.naturalWidth;
 
   const region = image.getBoundingClientRect();
+  console.log(region)
+  console.log(width)
 
   const scaledWidth = region.width * options.highlightScale;
   const scaledHeight = region.height * options.highlightScale;


### PR DESCRIPTION
## Why? What?

Support multiple images being highlighted at one using multiple concurrent runners

Fixes #9 

## ToDo / Known Issues

- [x] Correctly determine region that will be blocked by highlighted image and prevent other runners from using this area

## Ideas for Next Iterations (Not This PR)

- Currently all of the runners will wait if their target area is blocked and try again next time it would be their turn.
While this ensures that the animation frequency remains consistent (on average an image pops up every `totalDuration / numWorkers` seconds, it might be worth considering if this is the desired behavior.
- Currently each worker chooses its target insertion area randomly, respecting only blocked rows but waiting until it can fill its target area no matter what. It should be considered if this is the desired behavior.
- [ ] The number of workers should scale with screensize/number of rows, similar to the behavior desired by #10 

## How to Test

- Set `yoursecret` in yaml
- `Docker compose up`
- Go to `0:0:0:0:3000:kiosk.html#yoursecret`
- There need to be enough images uploaded in order to fill the full screen
- Observe multiple images popped out and highlighted at a time
- 