### PR TITLE
calculate rows based on device pixel ratio

### DIFF
--- a/frontend/kiosk.js
+++ b/frontend/kiosk.js
@@ -13,10 +13,20 @@ const options = {
   popDownDuration: baseDuration * 0.75,
   allowedRelativeWidthFromCenterForAdditions: 0.4, // from center in one direction, so actually twice
   easing: "cubic-bezier(0.65, 0.05, 0.36, 1)",
-  amountOfRows: 5,
+  amountOfRows: calculateRowCount(),
   stopIteration: false,
   secret: window.location.hash.substring(1),
 };
+
+function calculateRowCount() {
+  const screenHeight = window.innerHeight;
+  const dpr = window.devicePixelRatio;
+
+  const baseRowHeight = 200; // A comfortable image height in CSS pixels
+  const visualScale = dpr > 2 ? 1.25 : 1; // Adjust slightly for high-DPI devices
+
+  return Math.max(2, Math.floor(screenHeight / (baseRowHeight * visualScale)));
+}
 
 class AwaitableCondition {
   constructor(conditionPredicate) {
@@ -211,7 +221,7 @@ async function addImage(options, rows, recommender) {
     imagesInRow,
     recommender,
   );
-  const width = (20 / image.naturalHeight) * image.naturalWidth;
+  const width = ((100 / options.amountOfRows) / image.naturalHeight) * image.naturalWidth;
   await animatePopUp(options, image, width);
   await sleep(options.highlightDuration);
   await Promise.all([


### PR DESCRIPTION
## Why? What?

Use device pixel ratio to determine number of rows to use.
 I.e a laptop screen will generally have 4 rows, regardless of the screen resolution because the screen isn't very large and having tiny but high resolution pictures does no one any good.

Fixes #10 

## ToDo / Known Issues

- [ ] On certain devices like phones this creates the issue that the number of selected rows (3-4 when phone is vertical) do not create enough horizontal space for any images to be added and the kiosk runs into an endless loop in the `addImagesUntilScreenIsFull` function 

## Ideas for Next Iterations (Not This PR)

## How to Test

- Set `yoursecret` in yaml
- `Docker compose up`
- Go to `0:0:0:0:3000:kiosk.html#yoursecret`
- Test on various devices, using Firefox to simulate different screen sizes is one option, preferably this should be tested on real screens/projectors etc. The idea is that at a comfortable viewing distance the images should always have a reasonable size.